### PR TITLE
APIs PT lesson fixes - use_glove => use-glove, utilities

### DIFF
--- a/notebooks/03_APIs/pt-text-classification/README.md
+++ b/notebooks/03_APIs/pt-text-classification/README.md
@@ -17,7 +17,7 @@ python text_classification/utils.py
 ## Training
 ```bash
 python text_classification/train.py \
-    --data-url https://raw.githubusercontent.com/madewithml/lessons/master/data/news.csv --lower --shuffle --use_glove
+    --data-url https://raw.githubusercontent.com/madewithml/lessons/master/data/news.csv --lower --shuffle --use-glove
 ```
 
 ## Inference

--- a/notebooks/03_APIs/pt-text-classification/text_classification/utils.py
+++ b/notebooks/03_APIs/pt-text-classification/text_classification/utils.py
@@ -87,6 +87,6 @@ if __name__ == '__main__':
     # Unzip and write embeddings (may take ~3-5 minutes)
     resp = urlopen('http://nlp.stanford.edu/data/glove.6B.zip')
     embeddings_dir = os.path.join(config.BASE_DIR, 'embeddings')
-    utilities.create_dirs(embeddings_dir)
+    create_dirs(embeddings_dir)
     with ZipFile(BytesIO(resp.read()), 'r') as zr:
         zr.extractall(embeddings_dir)


### PR DESCRIPTION
Noticed two things when following the [API README](https://github.com/madewithml/lessons/blob/master/notebooks/03_APIs/pt-text-classification/README.md) instructions:

> python text_classification/utils.py

This fails with:

```
Traceback (most recent call last):
  File "text_classification/utils.py", line 90, in <module>
    utilities.create_dirs(embeddings_dir)
NameError: name 'utilities' is not defined
```

Looks like `create_dirs()` is defined in the same `utils.py` file.

The training step says:

> python text_classification/train.py \
    --data-url https://raw.githubusercontent.com/madewithml/lessons/master/data/news.csv --lower --shuffle --use_glove

Which fails:

```
train.py: error: unrecognized arguments: --use_glove
```

I think `--use_glove` should be `--use-glove`.